### PR TITLE
cambie el engine_mode y elimine el enable_http_endpoint

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -205,13 +205,12 @@ resource "aws_db_subnet_group" "db_subnet_group" {
 resource "aws_rds_cluster" "aurora_cluster" {
   cluster_identifier      = "aurora-cluster"
   engine                  = "aurora-mysql"
-  engine_mode             = "serverless"
+  engine_mode             = "provisioned"
   master_username = var.db_username
   master_password = var.db_password
   skip_final_snapshot     = true
   db_subnet_group_name    = aws_db_subnet_group.db_subnet_group.name
   vpc_security_group_ids  = [aws_security_group.db_sg.id]
-  enable_http_endpoint    = true
   tags = {
     Name = "AuroraCluster"
   }


### PR DESCRIPTION
## Summary by Sourcery

Update RDS cluster configuration by switching to provisioned engine mode and removing the HTTP endpoint option.

Enhancements:
- Change RDS cluster engine mode from serverless to provisioned.

Chores:
- Remove enable_http_endpoint from RDS cluster configuration.